### PR TITLE
centered items' text for schedule page cards

### DIFF
--- a/src/assets/scss/schedule.scss
+++ b/src/assets/scss/schedule.scss
@@ -59,7 +59,7 @@
 .schedule-card {
   @extend .btn;
   @extend .card-primary;
-
+  display: block;
   margin: 20px;
   min-width: -moz-available;
   min-width: -webkit-fill-available;

--- a/src/assets/scss/schedule.scss
+++ b/src/assets/scss/schedule.scss
@@ -59,6 +59,7 @@
 .schedule-card {
   @extend .btn;
   @extend .card-primary;
+
   display: block;
   margin: 20px;
   min-width: -moz-available;


### PR DESCRIPTION
## Description

Updated the schedule.scss to include display:block in order to disable the display flex that was being inherited automatically. In Chrome, the display:flex caused the text items to align to the left. Disabling that re-centered the text to appear as it does on Firefox.

## Issues Fixed
None

## Breaking Changes
### Confirmed Breaking Changes
- None

### Possible Breaking Changes
- None

## Changelog
- Added display: block to the  schedule-card class 
