### PR TITLE
fixed header wrapping to adjust text without hardcoded padding at the…

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -34,8 +34,8 @@ export class Header extends BaseElement{
       }
       .navbar-item {
         font-size: 1.25em;
-        margin-left: 75px;
-        margin-right: 75px;
+        margin-left: auto;
+        margin-right: auto;
       }
       .navbar-link {
         color: #fff !important;


### PR DESCRIPTION
… edges of the navbar -- everything stays on one line now

## Description

Removed pixel padding for right and left margins on the .nav-items class; added auto instead. Checked header after change on both Chrome and Firefox.

## Issues Fixed
None

## Breaking Changes
### Confirmed Breaking Changes
- None

### Possible Breaking Changes
- None

## Changelog
- Left and Right padding changed from 75px to "auto" on .nav-item class in header.js
