### PR TITLE
removed target blank that causes new tab to open whenever link on foo…

### DIFF
--- a/src/pages/offerings.html
+++ b/src/pages/offerings.html
@@ -6,7 +6,6 @@
         <meta property="og:description" content="ASU's Cybersecurity Club" />
         <meta property="og:image" content="../assets/img/DevilSecLogo.png" />
         <meta property="og:type" content="website" />
-        <base target="_blank">
     </head>
     <body>
         <div class="container-fluid row text-center justify-content-center">


### PR DESCRIPTION
…ter or header was clicked

## Description

Removed <base target="_blank">  as it was not intended for this page -- I think it's a carry over from the resources page, where we wanted external sites to open in a new tab. Now all links internal to the site will open in the current tab, as opposed to opening in a new tab.

## Issues Fixed
- None

## Breaking Changes
### Confirmed Breaking Changes
- None

### Possible Breaking Changes
- None

## Changelog
- Removed base tag
