### PR TITLE
this is so cursed

### DIFF
--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -15,7 +15,7 @@
             <p>DevilSec holds weekly formal meetings throughout the Fall and Spring semesters that cover a range of topics starting from using a virtual machine with Linux, to learning different tools such as web proxies and port scanners, and eventually to utilizing actual exploits for vulnerabilities in practice labs to get hands on experience. The group also has informal meetings for members that want to walk though a machine on HackTheBox or just be around to chat and answer questions.
             </p>
         </div>
-        <div class="container-fluid row text-center">
+        <div class="container-fluid row text-center" style="padding-bottom: 1190px !important;">
             <h3>Founders</h3>
             <div class="row">
                 <div class="col profile">

--- a/src/pages/offerings.html
+++ b/src/pages/offerings.html
@@ -8,7 +8,7 @@
         <meta property="og:type" content="website" />
     </head>
     <body>
-        <div class="container-fluid row text-center justify-content-center">
+        <div class="container-fluid row text-center justify-content-center" style="padding-bottom: 1250px !important;">
             <h1>What does DevilSec offer?</h1>
             <div class="card">
                 <img src="/src/assets/img/mentor.jpg" class="card-img-top">

--- a/src/pages/schedule.html
+++ b/src/pages/schedule.html
@@ -124,7 +124,7 @@
 
                 <hr class="schedule-divider">
 
-                <div class="container-fluid text-center px-4">
+                <div class="container-fluid text-center px-4" style="padding-bottom: 1325px !important;">
                     <div class="row gx-5">
                         <div class="col-lg-4">
                             <div class="schedule-category">


### PR DESCRIPTION
## Description

This is a really wonky way to push the footer down, but alas I haven't found a better way to do it. It works OK on Firefox. For Chromium browser, the schedule and about pages show signs of the footer crawling back up, but you have to be below 30% zoom to see the footer rising up from the bottom of the page (so the likelihood of someone noticing that is less). However, this "fix" introduces a scroll bar, which is not optimal, to get to the bottom of the page. 

## Issues Fixed
- None

## Breaking Changes
### Confirmed Breaking Changes
- None

### Possible Breaking Changes
- None

## Changelog
- Added `style="padding-bottom: 1200px !important;"` to troublesome pages
